### PR TITLE
Fix typo:  error_message did not have access to variables request or e

### DIFF
--- a/lib/handle_invalid_percent_encoding_requests/middleware.rb
+++ b/lib/handle_invalid_percent_encoding_requests/middleware.rb
@@ -20,16 +20,14 @@ module HandleInvalidPercentEncodingRequests
     # Rescue from that specific ArgumentError
     rescue ArgumentError => e
       raise unless e.message =~ /invalid %-encoding/
+
+      @logger.info "Bad request. Returning 400 due to #{e.message} from request with env #{request.inspect}"
       error_response
     end
-
 
     private
 
     def error_response
-      @logger.info "Bad request. Returning 400 due to #{e.message}" + \
-                  " from request with env #{request.inspect}"
-
       headers = { 'Content-Type' => "text/plain; charset=utf-8" }
       text = "Bad Request"
       [400, headers, [text]]


### PR DESCRIPTION
The logger statement does not have access to the variables 'request' or 'e', so it needs to be moved into the rescue block.
