### PR TITLE
Middleware: save exception in variable

### DIFF
--- a/lib/handle_invalid_percent_encoding_requests/middleware.rb
+++ b/lib/handle_invalid_percent_encoding_requests/middleware.rb
@@ -42,7 +42,7 @@ module HandleInvalidPercentEncodingRequests
 
     rescue InvalidPercentEncodingErrorMatcher,
            InvalidByteSequenceErrorMatcher,
-           NullByteErrorMatcher
+           NullByteErrorMatcher => e
 
       @logger.info "Bad request. Returning 400 due to #{e.class.name} " \
                    "#{e.message.inspect} from request with env " \


### PR DESCRIPTION
79e6565b18cbe31bd478ff3d9af55e98cce59b04 stopped saving the exception into `e`, which means whenever this gem tries to handle an exception it throws another due to the use of an "undefined local variable or method 'e'". Fix this by reverting that particular part of the commit, and continue saving the exception into `e` for use in the log message.